### PR TITLE
moving into cycloid-resource with feature field

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ A concourse resource is composed by three components:
 
 This three programs must be executable, you can use bash, python or binary the important thing is to be able to understand the input params and to output the correct information. This [doc](https://concourse-ci.org/implementing-resource-types.html) will help you to understand the params expected for each component.
 
-`infrapolicy-resource` will mainly run the `out` program, since it's a `put` in the pipeline definition, the worfklow is the following:
+`cycloid-resource` will mainly run the `out` program, since it's a `put` in the pipeline definition, the worfklow is the following:
 
 1. put:
 2. put will call the `./out` program
@@ -31,6 +31,7 @@ You first need to define a `source` JSON:
 ```json
 {
         "source": {
+                "feature": "terracost",
                 "env": "your-env",
                 "project": "your-project",
                 "org": "your-org",

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM golang:1.15.5-alpine3.12 as builder
 
 RUN apk add make
-WORKDIR /go/src/github.com/cycloidio/infrapolicy-resource
+WORKDIR /go/src/github.com/cycloidio/cycloid-resource
 COPY . ./
 RUN make
 
 FROM alpine:3.12
-COPY --from=builder /go/src/github.com/cycloidio/infrapolicy-resource/resource/ /opt/resource
+COPY --from=builder /go/src/github.com/cycloidio/cycloid-resource/resource/ /opt/resource
 
 RUN set -e; \
 	apk add --no-cache --virtual .build-deps \

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ First, declare your new resource type:
 
 ```yaml
 resource_types:
-  - name: infrapolicy
+  - name: cycloid-resource
     type: docker-image
     source:
-      repository: cycloid/infrapolicy-resource
+      repository: cycloid/cycloid-resource
       tag: latest
 ```
 
@@ -20,9 +20,22 @@ Then configure your resource:
 
 ```yaml
 resources:
-  - name: check
-    type: infrapolicy
+
+# Infrapolicy resource
+  - name: infrapolicy
+    type: cycloid-resource
     source:
+      feature: infrapolicy
+      api_key: <api-key>
+      env: ((env))
+      org: ((org))
+      project: ((project))
+
+# Terracost resource
+  - name: terracost
+    type: cycloid-resource
+    source:
+      feature: terracost
       api_key: <api-key>
       env: ((env))
       org: ((org))
@@ -44,6 +57,8 @@ Finally, add the `put` step right after the terraform plan and don't forget to t
 ## Parameters 
 
 ### Source configuration
+
+`feature`: _required_. The name of Cycloid feature to use, `terracost` or `infrapolicy`
 
 `api_key`: _required_. The Cycloid API key used to authenticate the resource against Cycloid APIs
 

--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/cycloidio/infrapolicy-resource/models"
+	"github.com/cycloidio/cycloid-resource/models"
 )
 
 func main() {
@@ -15,7 +15,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	out := []models.Version{
+	if err := req.Source.Validate(); err != nil {
+		fmt.Fprintf(os.Stderr, "Resource configuration error: %v", err)
+		os.Exit(1)
+	}
+
+	out := []models.GenericVersion{
 		req.Version,
 	}
 
@@ -25,5 +30,4 @@ func main() {
 		os.Exit(1)
 	}
 	fmt.Println(string(output))
-
 }

--- a/cmd/in/main.go
+++ b/cmd/in/main.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/cycloidio/infrapolicy-resource/models"
+	"github.com/cycloidio/cycloid-resource/models"
 )
 
 func main() {
@@ -21,20 +21,33 @@ func main() {
 		os.Exit(1)
 	}
 
-	criticals, err := strconv.Atoi(req.Version.Criticals)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "unable to get number of criticals check: %v", err)
-		os.Exit(1)
-	}
-	warnings, err := strconv.Atoi(req.Version.Warnings)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "unable to get number of warnings check: %v", err)
+	if err := req.Source.Validate(); err != nil {
+		fmt.Fprintf(os.Stderr, "Resource configuration error: %v", err)
 		os.Exit(1)
 	}
 
-	if criticals > 0 || warnings > 0 {
-		fmt.Fprint(os.Stderr, "critical or warning checks are present, check metadata of your resource for more information")
-		os.Exit(1)
+	feature, _ := req.Source.GetFeature()
+	if feature == models.InfraPolicy {
+		InfraPolicyVersion, ok := req.Version.(models.InfraPolicyVersion)
+		if ! ok {
+			fmt.Fprintf(os.Stderr, "Unable to decode the version passed as argument")
+			os.Exit(1)
+		}
+		criticals, err := strconv.Atoi(InfraPolicyVersion.Criticals)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "unable to get number of criticals check: %v", err)
+			os.Exit(1)
+		}
+		warnings, err := strconv.Atoi(InfraPolicyVersion.Warnings)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "unable to get number of warnings check: %v", err)
+			os.Exit(1)
+		}
+
+		if criticals > 0 || warnings > 0 {
+			fmt.Fprint(os.Stderr, "critical or warning checks are present, check metadata of your resource for more information")
+			os.Exit(1)
+		}
 	}
 
 	resp := models.OutResponse{

--- a/cmd/out/main.go
+++ b/cmd/out/main.go
@@ -7,7 +7,7 @@ import (
 	"os/exec"
 	"strconv"
 
-	"github.com/cycloidio/infrapolicy-resource/models"
+	"github.com/cycloidio/cycloid-resource/models"
 )
 
 type Result struct {
@@ -25,9 +25,8 @@ type Estimation struct {
 	PriorCost   string `json:"prior_cost"`
 }
 
-// terracost will run a terracost
-// estimation
-func terracost(org, tfplan, apiURL string) ([]models.Metadata, error) {
+// terracost will run a terracost estimation
+func terracost(org, tfplan, apiURL string) (models.GenericVersion, []models.Metadata, error) {
 	terracostArgs := []string{
 		"terracost",
 		"estimate",
@@ -42,7 +41,7 @@ func terracost(org, tfplan, apiURL string) ([]models.Metadata, error) {
 	}
 	out, err := exec.Command("cy", terracostArgs...).Output()
 	if err != nil {
-		return nil, fmt.Errorf("unable to estimate terraform plan costs: %w\n", err)
+		return nil, nil, fmt.Errorf("unable to estimate terraform plan costs: %w\n", err)
 	}
 
 	// Output the terracost estimate JSON that will be used by the cycloid console
@@ -50,88 +49,50 @@ func terracost(org, tfplan, apiURL string) ([]models.Metadata, error) {
 
 	var res Estimation
 	if err := json.Unmarshal(out, &res); err != nil {
-		return nil, fmt.Errorf("unable to unmarshal from cy output: %w\n", err)
+		return nil, nil, fmt.Errorf("unable to unmarshal from cy output: %w\n", err)
 	}
 
-	return []models.Metadata{
+	var version models.TerraCostVersion
+	version.BuildID = os.Getenv("BUILD_ID")
+
+	metadatas := []models.Metadata{
 		models.Metadata{Name: "planned_cost", Value: res.PlannedCost},
 		models.Metadata{Name: "prior_cost", Value: res.PriorCost},
-	}, nil
+	}
+
+	return version, metadatas, nil
 }
 
-func main() {
-	if len(os.Args) < 2 {
-		fmt.Fprint(os.Stderr, "expected path to sources as first argument")
-		os.Exit(1)
-	}
-	sourceDir := os.Args[1]
-	if err := os.Chdir(sourceDir); err != nil {
-		fmt.Fprintf(os.Stderr, "unable to access source dir: %v", err)
-		os.Exit(1)
-	}
-
-	var req models.OutRequest
-	if err := json.NewDecoder(os.Stdin).Decode(&req); err != nil {
-		fmt.Fprintf(os.Stderr, "unable to read from stdin: %v", err)
-		os.Exit(1)
-	}
-
-	if req.Source.ApiKey == "" {
-		fmt.Fprint(os.Stderr, "api_key is required")
-		os.Exit(1)
-	}
-
-	if req.Source.Org == "" || req.Source.Env == "" || req.Source.Project == "" {
-		fmt.Fprint(os.Stderr, "org, env and project are required")
-		os.Exit(1)
-	}
-
-	loginArgs := []string{
-		"login",
-		"--org",
-		req.Source.Org,
-		"--api-key",
-		req.Source.ApiKey,
-		"--api-url",
-		req.Source.ApiURL,
-	}
-
-	if _, err := exec.Command("cy", loginArgs...).Output(); err != nil {
-		fmt.Fprintf(os.Stderr, "unable to login to Cycloid: %v", err)
-		os.Exit(1)
-	}
-
-	validateArgs := []string{
+// terracost will run an infrapolicy check
+func infrapolicy(org, project, env, tfplan, apiURL string) (models.GenericVersion, []models.Metadata, error) {
+	cmdArgs := []string{
 		"infrapolicy",
 		"validate",
 		"--org",
-		req.Source.Org,
+		org,
 		"--api-url",
-		req.Source.ApiURL,
+		apiURL,
 		"--env",
-		req.Source.Env,
+		env,
 		"--project",
-		req.Source.Project,
+		project,
 		"--plan-path",
-		req.Params.TFPlanPath,
+		tfplan,
 		"-o",
 		"json",
 	}
-
-	out, err := exec.Command("cy", validateArgs...).Output()
+	out, err := exec.Command("cy", cmdArgs...).Output()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "unable to validate terraform plan: %v", err)
-		os.Exit(1)
+		return nil, nil, fmt.Errorf("unable to estimate infrapolicy plan costs: %w\n", err)
 	}
 
 	var res Result
 	if err := json.Unmarshal(out, &res); err != nil {
-		fmt.Fprintf(os.Stderr, "unable to unmarshal from cy output: %v", err)
-		os.Exit(1)
+		return nil, nil, fmt.Errorf("unable to unmarshal from cy output: %w\n", err)
 	}
 
 	var (
-		version   models.Version
+		version   models.InfraPolicyVersion
 		metadatas []models.Metadata
 	)
 
@@ -172,17 +133,76 @@ func main() {
 		version.Advisories = "0"
 	}
 
-	if req.Params.Terracost {
-		estimations, err := terracost(req.Source.Org, req.Params.TFPlanPath, req.Source.ApiURL)
+	version.BuildID = os.Getenv("BUILD_ID")
+
+	return version, metadatas, nil
+
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprint(os.Stderr, "expected path to sources as first argument")
+		os.Exit(1)
+	}
+	sourceDir := os.Args[1]
+	if err := os.Chdir(sourceDir); err != nil {
+		fmt.Fprintf(os.Stderr, "unable to access source dir: %v", err)
+		os.Exit(1)
+	}
+
+	var req models.OutRequest
+	if err := json.NewDecoder(os.Stdin).Decode(&req); err != nil {
+		fmt.Fprintf(os.Stderr, "unable to read from stdin: %v", err)
+		os.Exit(1)
+	}
+
+	if err := req.Source.Validate(); err != nil {
+		fmt.Fprintf(os.Stderr, "Resource configuration error: %v", err)
+		os.Exit(1)
+	}
+
+	loginArgs := []string{
+		"login",
+		"--org",
+		req.Source.Org,
+		"--api-key",
+		req.Source.ApiKey,
+		"--api-url",
+		req.Source.ApiURL,
+	}
+
+	if _, err := exec.Command("cy", loginArgs...).Output(); err != nil {
+		fmt.Fprintf(os.Stderr, "unable to login to Cycloid: %v", err)
+		os.Exit(1)
+	}
+
+	var (
+		version   models.GenericVersion
+		metadatas []models.Metadata
+		err       error
+	)
+
+	switch feature, _ := req.Source.GetFeature(); feature {
+	case models.TerraCost:
+		version, metadatas, err = terracost(req.Source.Org, req.Params.TFPlanPath, req.Source.ApiURL)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "unable to run terracost check: %v", err)
 			os.Exit(1)
 		}
-		metadatas = append(metadatas, estimations...)
+
+	case models.InfraPolicy:
+		version, metadatas, err = infrapolicy(req.Source.Org, req.Source.Project, req.Source.Env, req.Params.TFPlanPath, req.Source.ApiURL)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "unable to run infrapolicy: %v", err)
+			os.Exit(1)
+		}
+
+	default:
+		fmt.Fprintf(os.Stderr, "Unknow configured feature named : %s", feature)
+		os.Exit(2)
 	}
 
-	version.BuildID = os.Getenv("BUILD_ID")
-	resp := models.OutResponse{
+	resp := &models.OutResponse{
 		Version:   version,
 		Metadatas: metadatas,
 	}

--- a/models/in.go
+++ b/models/in.go
@@ -1,7 +1,7 @@
 package models
 
 type InRequest struct {
-	Source  Source  `json:"source"`
-	Version Version `json:"version"`
-	Params  Params  `json:"params"`
+	Source  Source         `json:"source"`
+	Version GenericVersion `json:"version"`
+	Params  Params         `json:"params"`
 }

--- a/models/out.go
+++ b/models/out.go
@@ -6,8 +6,8 @@ type OutRequest struct {
 }
 
 type OutResponse struct {
-	Version   Version    `json:"version"`
-	Metadatas []Metadata `json:"metadata"`
+	Version   GenericVersion `json:"version"`
+	Metadatas []Metadata     `json:"metadata"`
 }
 
 type Metadata struct {

--- a/models/source.go
+++ b/models/source.go
@@ -1,9 +1,50 @@
 package models
 
+import (
+	"fmt"
+	"strings"
+)
+
+const InfraPolicy = "infrapolicy"
+const TerraCost = "terracost"
+
 type Source struct {
-	ApiKey   string `json:"api_key"`
-	Org      string `json:"org"`
-	Project  string `json:"project"`
-	Env      string `json:"env"`
-	ApiURL   string `json:"api_url"`
+	// Feature is the name of the Cycloid feature eg infrapolicy, terracost
+	Feature string `json:"feature"`
+	ApiKey  string `json:"api_key"`
+	Org     string `json:"org"`
+	Project string `json:"project"`
+	Env     string `json:"env"`
+	ApiURL  string `json:"api_url"`
+}
+
+// GetFeature returns the feature configured
+func (s Source) GetFeature() (string, error) {
+	f := strings.ToLower(s.Feature)
+
+	if f == "" {
+		return "", fmt.Errorf("feature field is empty")
+	}
+	if f != InfraPolicy && f != TerraCost {
+		return "", fmt.Errorf("feature field should match %s", strings.Join([]string{InfraPolicy, TerraCost}, ", "))
+	}
+
+	return f, nil
+}
+
+func (s Source) Validate() error {
+	var err error
+
+	_, ferr := s.GetFeature()
+	if ferr != nil {
+		err = fmt.Errorf("feature configuration error: %v", ferr)
+	}
+	if s.ApiKey == "" {
+		err = fmt.Errorf("api_key is required")
+	}
+	if s.Org == "" || s.Env == "" || s.Project == "" {
+		err = fmt.Errorf("org, env and project are required")
+	}
+
+	return err
 }

--- a/models/versions.go
+++ b/models/versions.go
@@ -1,8 +1,14 @@
 package models
 
-type Version struct {
+type GenericVersion interface{}
+
+type InfraPolicyVersion struct {
 	BuildID    string `json:"build_id"`
 	Criticals  string `json:"criticals"`
 	Warnings   string `json:"warnings"`
 	Advisories string `json:"advisories"`
+}
+
+type TerraCostVersion struct {
+	BuildID string `json:"build_id"`
 }


### PR DESCRIPTION
Now this resource have a "feature" configuration field.
This field is here to define the behavior of the resource.

The previous implementation had few issues with Concourse logic when used
for infrapolicy and terracost.

Now both are concidered as 2 features and have their own version and display system.

Note the user will now have to define 2 resource of this type to be able to use both Cycloid
features in the pipeline